### PR TITLE
let structural elements also be in the dotted path

### DIFF
--- a/src/yafowil/base.py
+++ b/src/yafowil/base.py
@@ -394,8 +394,7 @@ class Widget(object):
         path = list()
         node = self
         while node is not None:
-            if not node.properties.get('structural'):
-                path.append(node.__name__)
+            path.append(node.__name__)
             node = node.__parent__
         path.reverse()
         return '.'.join(path)


### PR DESCRIPTION
structural elements ARE in the DOM tree and thus should have a dotted path too.
they should just be ignored in extractors.

even with this change, everything seems still to work. the failing tests were failing before.

WHY I PROPOSE THIS CHANGE:
if you define multiple fieldsets and all structural, those get all the same cssid. this is invalid html then and i need actually valid ids on structural fieldsets (except if it would adress them via a css class).
another way to fix this would be in the fieldset_renderer to check if the element is a structural element, and if so, call cssid like so
`cssid(widget, 'fieldset', postfix=widget.name)`
